### PR TITLE
Update granularAuth.gs

### DIFF
--- a/granularAuth.gs
+++ b/granularAuth.gs
@@ -132,11 +132,11 @@ function _showAllScopesRequiredMessage() {
   }
   else {
     const ui = _getActiveUi();
-    let message = `${title}\\n\\nTo operate properly, ${AUTH_APP_NAME} requires that you approve all  \
+    let message = `${title}\n\nTo operate properly, ${AUTH_APP_NAME} requires that you approve all  \
                       of its listed permissions (scopes) during installation. \
-                      \\n\\nPlease visit the link below in a new tab to re-authorize ${AUTH_APP_NAME}, and \
+                      \n\nPlease visit the link below in a new tab to re-authorize ${AUTH_APP_NAME}, and \
                       be sure to select all of the permissions listed there.
-                      Afterwards, close this window and access ${AUTH_APP_NAME} again.\\n\\n${reAuthUrl}`;
+                      Afterwards, close this window and access ${AUTH_APP_NAME} again.\n\n${reAuthUrl}`;
     if (ui) {
         // Use the cross-compatible Ui.alert() for the fallback message.
         ui.alert(title, message, ui.ButtonSet.OK);


### PR DESCRIPTION
Replaced `\\`n with `\n` to show correct message spaces

<img width="587" height="417" alt="image" src="https://github.com/user-attachments/assets/e6644615-c5af-4c45-abaa-2b3b89e39ef8" />
